### PR TITLE
Simulation Models Updates

### DIFF
--- a/bin/p4def_to_simv.py
+++ b/bin/p4def_to_simv.py
@@ -444,8 +444,7 @@ def main():
                         format_char = "%d"
 
                     stream.write(f"\n    if (({param} < {minval}) || ({param} > {maxval})) begin\n")
-                    stream.write(f"       $display(\"{name} instance %m {param} set to incorrect value, {format_char}.  Values must be between {minval} and {maxval}.\", {param});\n")
-                    stream.write("    #1 $stop;\n")
+                    stream.write(f"       $fatal(1,\"{name} instance %m {param} set to incorrect value, {format_char}.  Values must be between {minval} and {maxval}.\", {param});\n")
                     stream.write("    end\n")
                     continue
 
@@ -469,8 +468,7 @@ def main():
                 stream.write(f"    case({param})\n")
                 stream.write(f"      {value_list_for_case}: begin end\n")
                 stream.write("      default: begin\n")
-                stream.write(f"        $display(\"\\nError: {name} instance %m has parameter {param} set to {format_char}.  Valid values are {value_list_for_msg}\\n\", {param});\n")
-                stream.write("        #1 $stop ;\n")
+                stream.write(f"        $fatal(1,\"\\nError: {name} instance %m has parameter {param} set to {format_char}.  Valid values are {value_list_for_msg}\\n\", {param});\n")
                 stream.write("      end\n")
                 stream.write("    endcase\n")
 
@@ -490,8 +488,7 @@ def main():
                         format_char = "%d"
 
                     stream.write(f"\n    if (({param} < {minval}) || ({param} > {maxval})) begin\n")
-                    stream.write(f"       $display(\"{name} instance %m {param} set to incorrect value, {format_char}.  Values must be between {minval} and {maxval}.\", {param});\n")
-                    stream.write("    #1 $stop;\n")
+                    stream.write(f"       $fatal(1,\"{name} instance %m {param} set to incorrect value, {format_char}.  Values must be between {minval} and {maxval}.\", {param});\n")
                     stream.write("    end\n")
                     continue
 
@@ -513,8 +510,7 @@ def main():
                 stream.write(f"\n    case({param})\n")
                 stream.write(f"      {value_list_for_case}: begin end\n")
                 stream.write("      default: begin\n")
-                stream.write(f"        $display(\"\\nError: {name} instance %m has parameter {param} set to %s.  Valid values are {value_list_for_msg}\\n\", {param});\n")
-                stream.write("        #1 $stop ;\n")
+                stream.write(f"        $fatal(1,\"\\nError: {name} instance %m has parameter {param} set to %s.  Valid values are {value_list_for_msg}\\n\", {param});\n")
                 stream.write("      end\n")
                 stream.write("    endcase\n")
 

--- a/models_customer/verilog/BOOT_CLOCK.v
+++ b/models_customer/verilog/BOOT_CLOCK.v
@@ -20,8 +20,7 @@ localparam HALF_PERIOD = PERIOD/2.0;
  initial begin
 
     if ((PERIOD < 16.0) || (PERIOD > 30.0)) begin
-       $display("BOOT_CLOCK instance %m PERIOD set to incorrect value, %f.  Values must be between 16.0 and 30.0.", PERIOD);
-    #1 $stop;
+       $fatal(1,"BOOT_CLOCK instance %m PERIOD set to incorrect value, %f.  Values must be between 16.0 and 30.0.", PERIOD);
     end
 
   end

--- a/models_customer/verilog/DSP19X2.v
+++ b/models_customer/verilog/DSP19X2.v
@@ -381,15 +381,13 @@ module DSP19X2 #(
 	always @(ACC_FIR)
 		if (ACC_FIR > 21)
 		begin
-			$display("WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
 		end
 	// If SHIFT_RIGHT is greater than 31, result is invalid
 	always @(SHIFT_RIGHT)
 		if (SHIFT_RIGHT > 31)
 		begin
-			$display("WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
 		end
 	
 	always@(*) 
@@ -397,7 +395,7 @@ module DSP19X2 #(
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		
@@ -409,24 +407,21 @@ module DSP19X2 #(
       "MULTIPLY_ADD_SUB" ,
       "MULTIPLY_ACCUMULATE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
       end
     endcase
     case(OUTPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
       end
     endcase
     case(INPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
       end
     endcase
 

--- a/models_customer/verilog/DSP38.v
+++ b/models_customer/verilog/DSP38.v
@@ -297,14 +297,14 @@ module DSP38 #(
 	// If ACC_FIR is greater than 43, result is invalid
 	always @(ACC_FIR)
 		if (ACC_FIR > 43)
-			$display("WARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
+			$fatal(1,"\nWARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
 
 	always@(*) 
 	begin
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		
@@ -316,24 +316,21 @@ module DSP38 #(
       "MULTIPLY_ADD_SUB" ,
       "MULTIPLY_ACCUMULATE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
       end
     endcase
     case(OUTPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
       end
     endcase
     case(INPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
       end
     endcase
 

--- a/models_customer/verilog/FIFO18KX2.v
+++ b/models_customer/verilog/FIFO18KX2.v
@@ -337,48 +337,42 @@ tdp_ram18kx2_inst
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH1);
       end
     endcase
     case(DATA_READ_WIDTH1)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH1);
       end
     endcase
     case(FIFO_TYPE1)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE1 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE1 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE1);
       end
     endcase
     case(DATA_WRITE_WIDTH2)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH2);
       end
     endcase
     case(DATA_READ_WIDTH2)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH2);
       end
     endcase
     case(FIFO_TYPE2)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE2 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE2 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE2);
       end
     endcase
 

--- a/models_customer/verilog/FIFO36K.v
+++ b/models_customer/verilog/FIFO36K.v
@@ -202,8 +202,7 @@ module FIFO36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter DATA_WRITE_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_WRITE_WIDTH);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter DATA_WRITE_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_WRITE_WIDTH);
       end
     endcase
     case(DATA_READ_WIDTH)
@@ -211,16 +210,14 @@ module FIFO36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter DATA_READ_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_READ_WIDTH);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter DATA_READ_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_READ_WIDTH);
       end
     endcase
     case(FIFO_TYPE)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter FIFO_TYPE set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter FIFO_TYPE set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE);
       end
     endcase
 

--- a/models_customer/verilog/I_BUF.v
+++ b/models_customer/verilog/I_BUF.v
@@ -31,8 +31,7 @@ module I_BUF #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: I_BUF instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 

--- a/models_customer/verilog/I_BUF_DS.v
+++ b/models_customer/verilog/I_BUF_DS.v
@@ -44,8 +44,7 @@ module I_BUF_DS #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
     case(IOSTANDARD)
@@ -66,16 +65,14 @@ module I_BUF_DS #(
       "SSTL_18_HP_DIFF" ,
       "SSTL_18_HR_DIFF": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
       end
     endcase
     case(DIFFERENTIAL_TERMINATION)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
       end
     endcase
 

--- a/models_customer/verilog/I_DELAY.v
+++ b/models_customer/verilog/I_DELAY.v
@@ -59,8 +59,7 @@ assign #(30.0ps + (21.56ps*dly_tap_val)) O = I;			// Adjusted Delay for TT corne
  initial begin
 
     if ((DELAY < 0) || (DELAY > 63)) begin
-       $display("I_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
-    #1 $stop;
+       $fatal(1,"I_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
     end
 
   end

--- a/models_customer/verilog/I_FAB.v
+++ b/models_customer/verilog/I_FAB.v
@@ -1,0 +1,19 @@
+`timescale 1ns/1ps
+`celldefine
+//
+// I_FAB simulation model
+// Marker Buffer for periphery to fabric transition
+//
+// Copyright (c) 2023 Rapid Silicon, Inc.  All rights reserved.
+//
+
+module I_FAB (
+  input I, // Input
+  output O // Output
+);
+
+assign O = I ;
+
+
+endmodule
+`endcelldefine

--- a/models_customer/verilog/I_SERDES.v
+++ b/models_customer/verilog/I_SERDES.v
@@ -758,22 +758,19 @@ assign DATA_VALID=!des_fifo_empty;
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: I_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: I_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
 
     if ((WIDTH < 3) || (WIDTH > 10)) begin
-       $display("I_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
-    #1 $stop;
+       $fatal(1,"I_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
     end
     case(DPA_MODE)
       "NONE" ,
       "DPA" ,
       "CDR": begin end
       default: begin
-        $display("\nError: I_SERDES instance %m has parameter DPA_MODE set to %s.  Valid values are NONE, DPA, CDR\n", DPA_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: I_SERDES instance %m has parameter DPA_MODE set to %s.  Valid values are NONE, DPA, CDR\n", DPA_MODE);
       end
     endcase
 

--- a/models_customer/verilog/O_BUFT.v
+++ b/models_customer/verilog/O_BUFT.v
@@ -31,8 +31,7 @@ module O_BUFT #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 

--- a/models_customer/verilog/O_BUFT_DS.v
+++ b/models_customer/verilog/O_BUFT_DS.v
@@ -35,8 +35,7 @@ module O_BUFT_DS #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: O_BUFT_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 

--- a/models_customer/verilog/O_DELAY.v
+++ b/models_customer/verilog/O_DELAY.v
@@ -59,8 +59,7 @@ assign #(30.0ps + (21.56ps*dly_tap_val)) O = I;				// Adjusted Delay for TT corn
  initial begin
 
     if ((DELAY < 0) || (DELAY > 63)) begin
-       $display("O_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
-    #1 $stop;
+       $fatal(1,"O_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
     end
 
   end

--- a/models_customer/verilog/O_FAB.v
+++ b/models_customer/verilog/O_FAB.v
@@ -1,0 +1,18 @@
+`timescale 1ns/1ps
+`celldefine
+//
+// O_FAB simulation model
+// Marker Buffer for fabric to periphery transition
+//
+// Copyright (c) 2023 Rapid Silicon, Inc.  All rights reserved.
+//
+
+module O_FAB (
+  input I, // Input
+  output O // Output
+);
+
+assign O = I ;
+
+endmodule
+`endcelldefine

--- a/models_customer/verilog/O_SERDES.v
+++ b/models_customer/verilog/O_SERDES.v
@@ -244,14 +244,12 @@ module O_SERDES #(
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: O_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
 
     if ((WIDTH < 3) || (WIDTH > 10)) begin
-       $display("O_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
-    #1 $stop;
+       $fatal(1,"O_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
     end
 
   end

--- a/models_customer/verilog/O_SERDES_CLK.v
+++ b/models_customer/verilog/O_SERDES_CLK.v
@@ -53,8 +53,7 @@ module O_SERDES_CLK #(
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: O_SERDES_CLK instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES_CLK instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
     case(CLOCK_PHASE)
@@ -63,8 +62,7 @@ module O_SERDES_CLK #(
       180 ,
       270: begin end
       default: begin
-        $display("\nError: O_SERDES_CLK instance %m has parameter CLOCK_PHASE set to %d.  Valid values are 0, 90, 180, 270\n", CLOCK_PHASE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES_CLK instance %m has parameter CLOCK_PHASE set to %d.  Valid values are 0, 90, 180, 270\n", CLOCK_PHASE);
       end
     endcase
 

--- a/models_customer/verilog/PLL.v
+++ b/models_customer/verilog/PLL.v
@@ -160,12 +160,10 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge CLK_IN) begin
 		if(pllstart_ff2)begin
 			if (ref_period<VCO_MIN_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m REF clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\n", $realtime, ref_period, VCO_MIN_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m REF clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\n", $realtime, ref_period, VCO_MIN_PERIOD);
 			end
 			else if (ref_period>VCO_MAX_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m REF clock period %0d fs violates maximum period.\nMust be less than %0d fs.\n", $realtime, ref_period, VCO_MAX_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m REF clock period %0d fs violates maximum period.\nMust be less than %0d fs.\n", $realtime, ref_period, VCO_MAX_PERIOD);
 			end
 		end
 	end
@@ -182,12 +180,10 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge FAST_CLK) begin
 		if(vcostart_ff) begin
 			if (vco_period<VCO_MIN_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m VCO clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\nTry increasing PLL_DIV or decreasing PLL_MULT values.\n", $realtime, vco_period, VCO_MIN_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m VCO clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\nTry increasing PLL_DIV or decreasing PLL_MULT values.\n", $realtime, vco_period, VCO_MIN_PERIOD);
 			end
 			else if (vco_period>VCO_MAX_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m VCO clock period %0d fs violates maximum period.\nMust be less than %0d fs.\nTry increasing PLL_MULT or decreasing PLL_DIV values.\n", $realtime, vco_period, VCO_MAX_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m VCO clock period %0d fs violates maximum period.\nMust be less than %0d fs.\nTry increasing PLL_MULT or decreasing PLL_DIV values.\n", $realtime, vco_period, VCO_MAX_PERIOD);
 			end
 		end
 	end
@@ -198,19 +194,16 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge CLK_IN, posedge PLL_EN) begin
 		if(PLL_EN)begin
 			if(PLL_POST_DIV0==0)begin
-				$display("Error at time %t: \n \t PLL instance %m, PLL_POST_DIV0 is equal to zero.\n \t Must be greater than 0", $realtime);
-            $stop;
+				$fatal(1,"Error at time %t: \n \t PLL instance %m, PLL_POST_DIV0 is equal to zero.\n \t Must be greater than 0", $realtime);
 			end
 
 			else if(PLL_POST_DIV1==0)begin
-				$display("Error at time %t: \n \t PLL instance %m, PLL_POST_DIV1 is equal to zero.\n \t Must be greater than 0", $realtime);
-				$stop;
+				$fatal(1,"Error at time %t: \n \t PLL instance %m, PLL_POST_DIV1 is equal to zero.\n \t Must be greater than 0", $realtime);
 			end
 
 
 			else if(PLL_POST_DIV1>PLL_POST_DIV0) begin
-				$display("Error at time %t: PLL_POST_DIV1 > PLL_POST_DIV0\n", $realtime);
-				$stop;
+				$fatal(1,"Error at time %t: PLL_POST_DIV1 > PLL_POST_DIV0\n", $realtime);
 			end
 		end
 	end
@@ -219,33 +212,28 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
     case(DEV_FAMILY)
       "VIRGO": begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter DEV_FAMILY set to %s.  Valid values are VIRGO\n", DEV_FAMILY);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter DEV_FAMILY set to %s.  Valid values are VIRGO\n", DEV_FAMILY);
       end
     endcase
     case(DIVIDE_CLK_IN_BY_2)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter DIVIDE_CLK_IN_BY_2 set to %s.  Valid values are TRUE, FALSE\n", DIVIDE_CLK_IN_BY_2);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter DIVIDE_CLK_IN_BY_2 set to %s.  Valid values are TRUE, FALSE\n", DIVIDE_CLK_IN_BY_2);
       end
     endcase
 
     if ((PLL_MULT < 16) || (PLL_MULT > 640)) begin
-       $display("PLL instance %m PLL_MULT set to incorrect value, %d.  Values must be between 16 and 640.", PLL_MULT);
-    #1 $stop;
+       $fatal(1,"PLL instance %m PLL_MULT set to incorrect value, %d.  Values must be between 16 and 640.", PLL_MULT);
     end
 
     if ((PLL_DIV < 1) || (PLL_DIV > 63)) begin
-       $display("PLL instance %m PLL_DIV set to incorrect value, %d.  Values must be between 1 and 63.", PLL_DIV);
-    #1 $stop;
+       $fatal(1,"PLL instance %m PLL_DIV set to incorrect value, %d.  Values must be between 1 and 63.", PLL_DIV);
     end
     case(PLL_MULT_FRAC)
       0: begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter PLL_MULT_FRAC set to %d.  Valid values are 0\n", PLL_MULT_FRAC);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter PLL_MULT_FRAC set to %d.  Valid values are 0\n", PLL_MULT_FRAC);
       end
     endcase
     case(PLL_POST_DIV)
@@ -278,8 +266,7 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
       103 ,
       119: begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter PLL_POST_DIV set to %d.  Valid values are 17, 18, 19, 20, 21, 22, 23, 34, 35, 36, 37, 38, 39, 51, 52, 53, 54, 55, 68, 69, 70, 71, 85, 86, 87, 102, 103, 119\n", PLL_POST_DIV);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter PLL_POST_DIV set to %d.  Valid values are 17, 18, 19, 20, 21, 22, 23, 34, 35, 36, 37, 38, 39, 51, 52, 53, 54, 55, 68, 69, 70, 71, 85, 86, 87, 102, 103, 119\n", PLL_POST_DIV);
       end
     endcase
 

--- a/models_customer/verilog/SOC_FPGA_TEMPERATURE.v
+++ b/models_customer/verilog/SOC_FPGA_TEMPERATURE.v
@@ -71,8 +71,7 @@ module SOC_FPGA_TEMPERATURE #(
  initial begin
 
     if ((INITIAL_TEMPERATURE < 0) || (INITIAL_TEMPERATURE > 125)) begin
-       $display("SOC_FPGA_TEMPERATURE instance %m INITIAL_TEMPERATURE set to incorrect value, %d.  Values must be between 0 and 125.", INITIAL_TEMPERATURE);
-    #1 $stop;
+       $fatal(1,"SOC_FPGA_TEMPERATURE instance %m INITIAL_TEMPERATURE set to incorrect value, %d.  Values must be between 0 and 125.", INITIAL_TEMPERATURE);
     end
 
   end

--- a/models_customer/verilog/TDP_RAM18KX2.v
+++ b/models_customer/verilog/TDP_RAM18KX2.v
@@ -844,8 +844,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A1);
       end
     endcase
     case(WRITE_WIDTH_B1)
@@ -855,8 +854,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B1);
       end
     endcase
     case(READ_WIDTH_A1)
@@ -866,8 +864,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A1);
       end
     endcase
     case(READ_WIDTH_B1)
@@ -877,8 +874,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B1);
       end
     endcase
     case(WRITE_WIDTH_A2)
@@ -888,8 +884,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A2);
       end
     endcase
     case(WRITE_WIDTH_B2)
@@ -899,8 +894,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B2);
       end
     endcase
     case(READ_WIDTH_A2)
@@ -910,8 +904,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A2);
       end
     endcase
     case(READ_WIDTH_B2)
@@ -921,8 +914,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B2);
       end
     endcase
 

--- a/models_customer/verilog/TDP_RAM36K.v
+++ b/models_customer/verilog/TDP_RAM36K.v
@@ -488,8 +488,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_A);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_A);
       end
     endcase
     case(READ_WIDTH_A)
@@ -500,8 +499,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_A);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_A);
       end
     endcase
     case(WRITE_WIDTH_B)
@@ -512,8 +510,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_B);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_B);
       end
     endcase
     case(READ_WIDTH_B)
@@ -524,8 +521,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_B);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_B);
       end
     endcase
 

--- a/models_internal/verilog/BOOT_CLOCK.v
+++ b/models_internal/verilog/BOOT_CLOCK.v
@@ -20,8 +20,7 @@ localparam HALF_PERIOD = PERIOD/2.0;
  initial begin
 
     if ((PERIOD < 16.0) || (PERIOD > 30.0)) begin
-       $display("BOOT_CLOCK instance %m PERIOD set to incorrect value, %f.  Values must be between 16.0 and 30.0.", PERIOD);
-    #1 $stop;
+       $fatal(1,"BOOT_CLOCK instance %m PERIOD set to incorrect value, %f.  Values must be between 16.0 and 30.0.", PERIOD);
     end
 
   end

--- a/models_internal/verilog/DSP19X2.v
+++ b/models_internal/verilog/DSP19X2.v
@@ -381,15 +381,13 @@ module DSP19X2 #(
 	always @(ACC_FIR)
 		if (ACC_FIR > 21)
 		begin
-			$display("WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
 		end
 	// If SHIFT_RIGHT is greater than 31, result is invalid
 	always @(SHIFT_RIGHT)
 		if (SHIFT_RIGHT > 31)
 		begin
-			$display("WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
 		end
 	
 	always@(*) 
@@ -397,7 +395,7 @@ module DSP19X2 #(
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		
@@ -409,24 +407,21 @@ module DSP19X2 #(
       "MULTIPLY_ADD_SUB" ,
       "MULTIPLY_ACCUMULATE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
       end
     endcase
     case(OUTPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
       end
     endcase
     case(INPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP19X2 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP19X2 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
       end
     endcase
 

--- a/models_internal/verilog/DSP38.v
+++ b/models_internal/verilog/DSP38.v
@@ -297,14 +297,14 @@ module DSP38 #(
 	// If ACC_FIR is greater than 43, result is invalid
 	always @(ACC_FIR)
 		if (ACC_FIR > 43)
-			$display("WARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
+			$fatal(1,"\nWARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
 
 	always@(*) 
 	begin
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		
@@ -316,24 +316,21 @@ module DSP38 #(
       "MULTIPLY_ADD_SUB" ,
       "MULTIPLY_ACCUMULATE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter DSP_MODE set to %s.  Valid values are MULTIPLY, MULTIPLY_ADD_SUB, MULTIPLY_ACCUMULATE\n", DSP_MODE);
       end
     endcase
     case(OUTPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter OUTPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", OUTPUT_REG_EN);
       end
     endcase
     case(INPUT_REG_EN)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: DSP38 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
-        #1 $stop ;
+        $fatal(1,"\nError: DSP38 instance %m has parameter INPUT_REG_EN set to %s.  Valid values are TRUE, FALSE\n", INPUT_REG_EN);
       end
     endcase
 

--- a/models_internal/verilog/FIFO18KX2.v
+++ b/models_internal/verilog/FIFO18KX2.v
@@ -337,48 +337,42 @@ tdp_ram18kx2_inst
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH1);
       end
     endcase
     case(DATA_READ_WIDTH1)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH1 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH1);
       end
     endcase
     case(FIFO_TYPE1)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE1 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE1);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE1 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE1);
       end
     endcase
     case(DATA_WRITE_WIDTH2)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_WRITE_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_WRITE_WIDTH2);
       end
     endcase
     case(DATA_READ_WIDTH2)
       9 ,
       18: begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter DATA_READ_WIDTH2 set to %d.  Valid values are 9, 18\n", DATA_READ_WIDTH2);
       end
     endcase
     case(FIFO_TYPE2)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE2 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE2);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO18KX2 instance %m has parameter FIFO_TYPE2 set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE2);
       end
     endcase
 

--- a/models_internal/verilog/FIFO36K.v
+++ b/models_internal/verilog/FIFO36K.v
@@ -202,8 +202,7 @@ module FIFO36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter DATA_WRITE_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_WRITE_WIDTH);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter DATA_WRITE_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_WRITE_WIDTH);
       end
     endcase
     case(DATA_READ_WIDTH)
@@ -211,16 +210,14 @@ module FIFO36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter DATA_READ_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_READ_WIDTH);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter DATA_READ_WIDTH set to %d.  Valid values are 9, 18, 36\n", DATA_READ_WIDTH);
       end
     endcase
     case(FIFO_TYPE)
       "SYNCHRONOUS" ,
       "ASYNCHRONOUS": begin end
       default: begin
-        $display("\nError: FIFO36K instance %m has parameter FIFO_TYPE set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE);
-        #1 $stop ;
+        $fatal(1,"\nError: FIFO36K instance %m has parameter FIFO_TYPE set to %s.  Valid values are SYNCHRONOUS, ASYNCHRONOUS\n", FIFO_TYPE);
       end
     endcase
 

--- a/models_internal/verilog/I_BUF.v
+++ b/models_internal/verilog/I_BUF.v
@@ -34,8 +34,7 @@ module I_BUF #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: I_BUF instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 
@@ -69,8 +68,7 @@ module I_BUF #(
       "SSTL_I_33" ,
       "SSTL_II_33": begin end
       default: begin
-        $display("\nError: I_BUF instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/models_internal/verilog/I_BUF_DS.v
+++ b/models_internal/verilog/I_BUF_DS.v
@@ -44,8 +44,7 @@ module I_BUF_DS #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
     case(IOSTANDARD)
@@ -66,16 +65,14 @@ module I_BUF_DS #(
       "SSTL_18_HP_DIFF" ,
       "SSTL_18_HR_DIFF": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
       end
     endcase
     case(DIFFERENTIAL_TERMINATION)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: I_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
-        #1 $stop ;
+        $fatal(1,"\nError: I_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
       end
     endcase
 

--- a/models_internal/verilog/I_DELAY.v
+++ b/models_internal/verilog/I_DELAY.v
@@ -59,8 +59,7 @@ assign #(30.0ps + (21.56ps*dly_tap_val)) O = I;			// Adjusted Delay for TT corne
  initial begin
 
     if ((DELAY < 0) || (DELAY > 63)) begin
-       $display("I_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
-    #1 $stop;
+       $fatal(1,"I_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
     end
 
   end

--- a/models_internal/verilog/I_FAB.v
+++ b/models_internal/verilog/I_FAB.v
@@ -1,0 +1,19 @@
+`timescale 1ns/1ps
+`celldefine
+//
+// I_FAB simulation model
+// Marker Buffer for periphery to fabric transition
+//
+// Copyright (c) 2023 Rapid Silicon, Inc.  All rights reserved.
+//
+
+module I_FAB (
+  input I, // Input
+  output O // Output
+);
+
+assign O = I ;
+
+
+endmodule
+`endcelldefine

--- a/models_internal/verilog/I_SERDES.v
+++ b/models_internal/verilog/I_SERDES.v
@@ -758,22 +758,19 @@ assign DATA_VALID=!des_fifo_empty;
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: I_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: I_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
 
     if ((WIDTH < 3) || (WIDTH > 10)) begin
-       $display("I_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
-    #1 $stop;
+       $fatal(1,"I_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
     end
     case(DPA_MODE)
       "NONE" ,
       "DPA" ,
       "CDR": begin end
       default: begin
-        $display("\nError: I_SERDES instance %m has parameter DPA_MODE set to %s.  Valid values are NONE, DPA, CDR\n", DPA_MODE);
-        #1 $stop ;
+        $fatal(1,"\nError: I_SERDES instance %m has parameter DPA_MODE set to %s.  Valid values are NONE, DPA, CDR\n", DPA_MODE);
       end
     endcase
 

--- a/models_internal/verilog/O_BUF.v
+++ b/models_internal/verilog/O_BUF.v
@@ -53,8 +53,7 @@ module O_BUF
       "SSTL_I_33" ,
       "SSTL_II_33": begin end
       default: begin
-        $display("\nError: O_BUF instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
       end
     endcase
 
@@ -66,8 +65,7 @@ module O_BUF
       12 ,
       16: begin end
       default: begin
-        $display("\nError: O_BUF instance %m has parameter DRIVE_STRENGTH set to %s.  Valid values are 2, 4, 6, 8, 12, 16\n", DRIVE_STRENGTH);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF instance %m has parameter DRIVE_STRENGTH set to %s.  Valid values are 2, 4, 6, 8, 12, 16\n", DRIVE_STRENGTH);
       end
     endcase
 
@@ -75,8 +73,7 @@ module O_BUF
       "SLOW" ,
       "FAST": begin end
       default: begin
-        $display("\nError: O_BUF instance %m has parameter SLEW_RATE set to %s.  Valid values are SLOW, FAST\n", SLEW_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF instance %m has parameter SLEW_RATE set to %s.  Valid values are SLOW, FAST\n", SLEW_RATE);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/models_internal/verilog/O_BUFT.v
+++ b/models_internal/verilog/O_BUFT.v
@@ -36,8 +36,7 @@ module O_BUFT #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 
@@ -71,8 +70,7 @@ module O_BUFT #(
       "SSTL_I_33" ,
       "SSTL_II_33": begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, LVCMOS_12, LVCMOS_15, LVCMOS_18_HP, LVCMOS_18_HR, LVCMOS_25, LVCMOS_33, LVTTL, HSTL_I_12, HSTL_II_12, HSTL_I_15, HSTL_II_15, HSUL_12, PCI66, PCIX133, POD_12, SSTL_I_15, SSTL_II_15, SSTL_I_18_HP, SSTL_II_18_HP, SSTL_I_18_HR, SSTL_II_18_HR, SSTL_I_25, SSTL_II_25, SSTL_I_33, SSTL_II_33\n", IOSTANDARD);
       end
     endcase
 
@@ -84,8 +82,7 @@ module O_BUFT #(
       12 ,
       16: begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter DRIVE_STRENGTH set to %s.  Valid values are 2, 4, 6, 8, 12, 16\n", DRIVE_STRENGTH);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter DRIVE_STRENGTH set to %s.  Valid values are 2, 4, 6, 8, 12, 16\n", DRIVE_STRENGTH);
       end
     endcase
 
@@ -93,8 +90,7 @@ module O_BUFT #(
       "SLOW" ,
       "FAST": begin end
       default: begin
-        $display("\nError: O_BUFT instance %m has parameter SLEW_RATE set to %s.  Valid values are SLOW, FAST\n", SLEW_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT instance %m has parameter SLEW_RATE set to %s.  Valid values are SLOW, FAST\n", SLEW_RATE);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/models_internal/verilog/O_BUFT_DS.v
+++ b/models_internal/verilog/O_BUFT_DS.v
@@ -39,8 +39,7 @@ module O_BUFT_DS #(
       "PULLUP" ,
       "PULLDOWN": begin end
       default: begin
-        $display("\nError: O_BUFT_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT_DS instance %m has parameter WEAK_KEEPER set to %s.  Valid values are NONE, PULLUP, PULLDOWN\n", WEAK_KEEPER);
       end
     endcase
 
@@ -64,8 +63,7 @@ module O_BUFT_DS #(
       "SSTL_18_HP_DIFF" ,
       "SSTL_18_HR_DIFF": begin end
       default: begin
-        $display("\nError: O_BUFT_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
       end
     endcase
 
@@ -73,8 +71,7 @@ module O_BUFT_DS #(
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: O_BUFT_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUFT_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/models_internal/verilog/O_BUF_DS.v
+++ b/models_internal/verilog/O_BUF_DS.v
@@ -45,8 +45,7 @@ module O_BUF_DS
       "SSTL_18_HP_DIFF" ,
       "SSTL_18_HR_DIFF": begin end
       default: begin
-        $display("\nError: O_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF_DS instance %m has parameter IOSTANDARD set to %s.  Valid values are DEFAULT, BLVDS_DIFF, LVDS_HP_DIFF, LVDS_HR_DIFF, LVPECL_25_DIFF, LVPECL_33_DIFF, HSTL_12_DIFF, HSTL_15_DIFF, HSUL_12_DIFF, MIPI_DIFF, POD_12_DIFF, RSDS_DIFF, SLVS_DIFF, SSTL_15_DIFF, SSTL_18_HP_DIFF, SSTL_18_HR_DIFF\n", IOSTANDARD);
       end
     endcase
 
@@ -54,8 +53,7 @@ module O_BUF_DS
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: O_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
-        #1 $stop ;
+        $fatal(1,"\nError: O_BUF_DS instance %m has parameter DIFFERENTIAL_TERMINATION set to %s.  Valid values are TRUE, FALSE\n", DIFFERENTIAL_TERMINATION);
       end
     endcase
 `endif // RAPIDSILICON_INTERNAL

--- a/models_internal/verilog/O_DELAY.v
+++ b/models_internal/verilog/O_DELAY.v
@@ -59,8 +59,7 @@ assign #(30.0ps + (21.56ps*dly_tap_val)) O = I;				// Adjusted Delay for TT corn
  initial begin
 
     if ((DELAY < 0) || (DELAY > 63)) begin
-       $display("O_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
-    #1 $stop;
+       $fatal(1,"O_DELAY instance %m DELAY set to incorrect value, %d.  Values must be between 0 and 63.", DELAY);
     end
 
   end

--- a/models_internal/verilog/O_FAB.v
+++ b/models_internal/verilog/O_FAB.v
@@ -1,0 +1,18 @@
+`timescale 1ns/1ps
+`celldefine
+//
+// O_FAB simulation model
+// Marker Buffer for fabric to periphery transition
+//
+// Copyright (c) 2023 Rapid Silicon, Inc.  All rights reserved.
+//
+
+module O_FAB (
+  input I, // Input
+  output O // Output
+);
+
+assign O = I ;
+
+endmodule
+`endcelldefine

--- a/models_internal/verilog/O_SERDES.v
+++ b/models_internal/verilog/O_SERDES.v
@@ -244,14 +244,12 @@ module O_SERDES #(
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: O_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
 
     if ((WIDTH < 3) || (WIDTH > 10)) begin
-       $display("O_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
-    #1 $stop;
+       $fatal(1,"O_SERDES instance %m WIDTH set to incorrect value, %d.  Values must be between 3 and 10.", WIDTH);
     end
 
   end

--- a/models_internal/verilog/O_SERDES_CLK.v
+++ b/models_internal/verilog/O_SERDES_CLK.v
@@ -53,8 +53,7 @@ module O_SERDES_CLK #(
       "SDR" ,
       "DDR": begin end
       default: begin
-        $display("\nError: O_SERDES_CLK instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES_CLK instance %m has parameter DATA_RATE set to %s.  Valid values are SDR, DDR\n", DATA_RATE);
       end
     endcase
     case(CLOCK_PHASE)
@@ -63,8 +62,7 @@ module O_SERDES_CLK #(
       180 ,
       270: begin end
       default: begin
-        $display("\nError: O_SERDES_CLK instance %m has parameter CLOCK_PHASE set to %d.  Valid values are 0, 90, 180, 270\n", CLOCK_PHASE);
-        #1 $stop ;
+        $fatal(1,"\nError: O_SERDES_CLK instance %m has parameter CLOCK_PHASE set to %d.  Valid values are 0, 90, 180, 270\n", CLOCK_PHASE);
       end
     endcase
 

--- a/models_internal/verilog/PLL.v
+++ b/models_internal/verilog/PLL.v
@@ -160,12 +160,10 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge CLK_IN) begin
 		if(pllstart_ff2)begin
 			if (ref_period<VCO_MIN_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m REF clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\n", $realtime, ref_period, VCO_MIN_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m REF clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\n", $realtime, ref_period, VCO_MIN_PERIOD);
 			end
 			else if (ref_period>VCO_MAX_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m REF clock period %0d fs violates maximum period.\nMust be less than %0d fs.\n", $realtime, ref_period, VCO_MAX_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m REF clock period %0d fs violates maximum period.\nMust be less than %0d fs.\n", $realtime, ref_period, VCO_MAX_PERIOD);
 			end
 		end
 	end
@@ -182,12 +180,10 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge FAST_CLK) begin
 		if(vcostart_ff) begin
 			if (vco_period<VCO_MIN_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m VCO clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\nTry increasing PLL_DIV or decreasing PLL_MULT values.\n", $realtime, vco_period, VCO_MIN_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m VCO clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\nTry increasing PLL_DIV or decreasing PLL_MULT values.\n", $realtime, vco_period, VCO_MIN_PERIOD);
 			end
 			else if (vco_period>VCO_MAX_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m VCO clock period %0d fs violates maximum period.\nMust be less than %0d fs.\nTry increasing PLL_MULT or decreasing PLL_DIV values.\n", $realtime, vco_period, VCO_MAX_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m VCO clock period %0d fs violates maximum period.\nMust be less than %0d fs.\nTry increasing PLL_MULT or decreasing PLL_DIV values.\n", $realtime, vco_period, VCO_MAX_PERIOD);
 			end
 		end
 	end
@@ -198,19 +194,16 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge CLK_IN, posedge PLL_EN) begin
 		if(PLL_EN)begin
 			if(PLL_POST_DIV0==0)begin
-				$display("Error at time %t: \n \t PLL instance %m, PLL_POST_DIV0 is equal to zero.\n \t Must be greater than 0", $realtime);
-            $stop;
+				$fatal(1,"Error at time %t: \n \t PLL instance %m, PLL_POST_DIV0 is equal to zero.\n \t Must be greater than 0", $realtime);
 			end
 
 			else if(PLL_POST_DIV1==0)begin
-				$display("Error at time %t: \n \t PLL instance %m, PLL_POST_DIV1 is equal to zero.\n \t Must be greater than 0", $realtime);
-				$stop;
+				$fatal(1,"Error at time %t: \n \t PLL instance %m, PLL_POST_DIV1 is equal to zero.\n \t Must be greater than 0", $realtime);
 			end
 
 
 			else if(PLL_POST_DIV1>PLL_POST_DIV0) begin
-				$display("Error at time %t: PLL_POST_DIV1 > PLL_POST_DIV0\n", $realtime);
-				$stop;
+				$fatal(1,"Error at time %t: PLL_POST_DIV1 > PLL_POST_DIV0\n", $realtime);
 			end
 		end
 	end
@@ -219,33 +212,28 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
     case(DEV_FAMILY)
       "VIRGO": begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter DEV_FAMILY set to %s.  Valid values are VIRGO\n", DEV_FAMILY);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter DEV_FAMILY set to %s.  Valid values are VIRGO\n", DEV_FAMILY);
       end
     endcase
     case(DIVIDE_CLK_IN_BY_2)
       "TRUE" ,
       "FALSE": begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter DIVIDE_CLK_IN_BY_2 set to %s.  Valid values are TRUE, FALSE\n", DIVIDE_CLK_IN_BY_2);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter DIVIDE_CLK_IN_BY_2 set to %s.  Valid values are TRUE, FALSE\n", DIVIDE_CLK_IN_BY_2);
       end
     endcase
 
     if ((PLL_MULT < 16) || (PLL_MULT > 640)) begin
-       $display("PLL instance %m PLL_MULT set to incorrect value, %d.  Values must be between 16 and 640.", PLL_MULT);
-    #1 $stop;
+       $fatal(1,"PLL instance %m PLL_MULT set to incorrect value, %d.  Values must be between 16 and 640.", PLL_MULT);
     end
 
     if ((PLL_DIV < 1) || (PLL_DIV > 63)) begin
-       $display("PLL instance %m PLL_DIV set to incorrect value, %d.  Values must be between 1 and 63.", PLL_DIV);
-    #1 $stop;
+       $fatal(1,"PLL instance %m PLL_DIV set to incorrect value, %d.  Values must be between 1 and 63.", PLL_DIV);
     end
     case(PLL_MULT_FRAC)
       0: begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter PLL_MULT_FRAC set to %d.  Valid values are 0\n", PLL_MULT_FRAC);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter PLL_MULT_FRAC set to %d.  Valid values are 0\n", PLL_MULT_FRAC);
       end
     endcase
     case(PLL_POST_DIV)
@@ -278,8 +266,7 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
       103 ,
       119: begin end
       default: begin
-        $display("\nError: PLL instance %m has parameter PLL_POST_DIV set to %d.  Valid values are 17, 18, 19, 20, 21, 22, 23, 34, 35, 36, 37, 38, 39, 51, 52, 53, 54, 55, 68, 69, 70, 71, 85, 86, 87, 102, 103, 119\n", PLL_POST_DIV);
-        #1 $stop ;
+        $fatal(1,"\nError: PLL instance %m has parameter PLL_POST_DIV set to %d.  Valid values are 17, 18, 19, 20, 21, 22, 23, 34, 35, 36, 37, 38, 39, 51, 52, 53, 54, 55, 68, 69, 70, 71, 85, 86, 87, 102, 103, 119\n", PLL_POST_DIV);
       end
     endcase
 

--- a/models_internal/verilog/SOC_FPGA_TEMPERATURE.v
+++ b/models_internal/verilog/SOC_FPGA_TEMPERATURE.v
@@ -71,8 +71,7 @@ module SOC_FPGA_TEMPERATURE #(
  initial begin
 
     if ((INITIAL_TEMPERATURE < 0) || (INITIAL_TEMPERATURE > 125)) begin
-       $display("SOC_FPGA_TEMPERATURE instance %m INITIAL_TEMPERATURE set to incorrect value, %d.  Values must be between 0 and 125.", INITIAL_TEMPERATURE);
-    #1 $stop;
+       $fatal(1,"SOC_FPGA_TEMPERATURE instance %m INITIAL_TEMPERATURE set to incorrect value, %d.  Values must be between 0 and 125.", INITIAL_TEMPERATURE);
     end
 
   end

--- a/models_internal/verilog/TDP_RAM18KX2.v
+++ b/models_internal/verilog/TDP_RAM18KX2.v
@@ -844,8 +844,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A1);
       end
     endcase
     case(WRITE_WIDTH_B1)
@@ -855,8 +854,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B1);
       end
     endcase
     case(READ_WIDTH_A1)
@@ -866,8 +864,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A1);
       end
     endcase
     case(READ_WIDTH_B1)
@@ -877,8 +874,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B1);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B1 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B1);
       end
     endcase
     case(WRITE_WIDTH_A2)
@@ -888,8 +884,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_A2);
       end
     endcase
     case(WRITE_WIDTH_B2)
@@ -899,8 +894,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter WRITE_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", WRITE_WIDTH_B2);
       end
     endcase
     case(READ_WIDTH_A2)
@@ -910,8 +904,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_A2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_A2);
       end
     endcase
     case(READ_WIDTH_B2)
@@ -921,8 +914,7 @@ module TDP_RAM18KX2 #(
       9 ,
       18: begin end
       default: begin
-        $display("\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B2);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM18KX2 instance %m has parameter READ_WIDTH_B2 set to %d.  Valid values are 1, 2, 4, 9, 18\n", READ_WIDTH_B2);
       end
     endcase
 

--- a/models_internal/verilog/TDP_RAM36K.v
+++ b/models_internal/verilog/TDP_RAM36K.v
@@ -488,8 +488,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_A);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_A);
       end
     endcase
     case(READ_WIDTH_A)
@@ -500,8 +499,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_A);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_A set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_A);
       end
     endcase
     case(WRITE_WIDTH_B)
@@ -512,8 +510,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_B);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter WRITE_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", WRITE_WIDTH_B);
       end
     endcase
     case(READ_WIDTH_B)
@@ -524,8 +521,7 @@ module TDP_RAM36K #(
       18 ,
       36: begin end
       default: begin
-        $display("\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_B);
-        #1 $stop ;
+        $fatal(1,"\nError: TDP_RAM36K instance %m has parameter READ_WIDTH_B set to %d.  Valid values are 1, 2, 4, 9, 18, 36\n", READ_WIDTH_B);
       end
     endcase
 

--- a/models_internal/verilog/inc/DSP19X2.inc.v
+++ b/models_internal/verilog/inc/DSP19X2.inc.v
@@ -339,15 +339,13 @@
 	always @(ACC_FIR)
 		if (ACC_FIR > 21)
 		begin
-			$display("WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m ACC_FIR input is %d which is greater than 21 which serves no function", ACC_FIR);
 		end
 	// If SHIFT_RIGHT is greater than 31, result is invalid
 	always @(SHIFT_RIGHT)
 		if (SHIFT_RIGHT > 31)
 		begin
-			$display("WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
-			#1 $finish ;
+			$fatal(1,"WARNING: DSP19x2 instance %m SHIFT_RIGHT input is %d which is greater than 31 which serves no function", SHIFT_RIGHT);
 		end
 	
 	always@(*) 
@@ -355,7 +353,7 @@
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP19x2 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		

--- a/models_internal/verilog/inc/DSP38.inc.v
+++ b/models_internal/verilog/inc/DSP38.inc.v
@@ -263,14 +263,14 @@
 	// If ACC_FIR is greater than 43, result is invalid
 	always @(ACC_FIR)
 		if (ACC_FIR > 43)
-			$display("WARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
+			$fatal(1,"\nWARNING: DSP38 instance %m ACC_FIR input is %d which is greater than 43 which serves no function", ACC_FIR);
 
 	always@(*) 
 	begin
 		case(DSP_MODE)
 			"MULTIPLY_ACCUMULATE": begin  
 				if(FEEDBACK>1)
-					$display("\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
+					$fatal(1,"\nWARNING: DSP38 instance %m has parameter DSP_MODE set to %s and FEEDBACK set to %0d. Valid values of FEEDBACK for this mode are 0,1 \n", DSP_MODE,FEEDBACK);
 			end
 		endcase
 		

--- a/models_internal/verilog/inc/I_FAB.inc.v
+++ b/models_internal/verilog/inc/I_FAB.inc.v
@@ -1,0 +1,3 @@
+
+assign O = I ;
+

--- a/models_internal/verilog/inc/O_FAB.inc.v
+++ b/models_internal/verilog/inc/O_FAB.inc.v
@@ -1,0 +1,2 @@
+
+assign O = I ;

--- a/models_internal/verilog/inc/PLL.inc.v
+++ b/models_internal/verilog/inc/PLL.inc.v
@@ -134,12 +134,10 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge CLK_IN) begin
 		if(pllstart_ff2)begin
 			if (ref_period<VCO_MIN_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m REF clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\n", $realtime, ref_period, VCO_MIN_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m REF clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\n", $realtime, ref_period, VCO_MIN_PERIOD);
 			end
 			else if (ref_period>VCO_MAX_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m REF clock period %0d fs violates maximum period.\nMust be less than %0d fs.\n", $realtime, ref_period, VCO_MAX_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m REF clock period %0d fs violates maximum period.\nMust be less than %0d fs.\n", $realtime, ref_period, VCO_MAX_PERIOD);
 			end
 		end
 	end
@@ -156,12 +154,10 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge FAST_CLK) begin
 		if(vcostart_ff) begin
 			if (vco_period<VCO_MIN_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m VCO clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\nTry increasing PLL_DIV or decreasing PLL_MULT values.\n", $realtime, vco_period, VCO_MIN_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m VCO clock period %0d fs violates minimum period.\nMust be greater than %0d fs.\nTry increasing PLL_DIV or decreasing PLL_MULT values.\n", $realtime, vco_period, VCO_MIN_PERIOD);
 			end
 			else if (vco_period>VCO_MAX_PERIOD) begin
-				$display("\nError at time %t: PLL instance %m VCO clock period %0d fs violates maximum period.\nMust be less than %0d fs.\nTry increasing PLL_MULT or decreasing PLL_DIV values.\n", $realtime, vco_period, VCO_MAX_PERIOD);
-				$stop;
+				$fatal(1,"\nError at time %t: PLL instance %m VCO clock period %0d fs violates maximum period.\nMust be less than %0d fs.\nTry increasing PLL_MULT or decreasing PLL_DIV values.\n", $realtime, vco_period, VCO_MAX_PERIOD);
 			end
 		end
 	end
@@ -172,19 +168,16 @@ localparam      FAST_LOCK      = 0; // Reduce lock time
 	always @ (posedge CLK_IN, posedge PLL_EN) begin
 		if(PLL_EN)begin
 			if(PLL_POST_DIV0==0)begin
-				$display("Error at time %t: \n \t PLL instance %m, PLL_POST_DIV0 is equal to zero.\n \t Must be greater than 0", $realtime);
-            $stop;
+				$fatal(1,"Error at time %t: \n \t PLL instance %m, PLL_POST_DIV0 is equal to zero.\n \t Must be greater than 0", $realtime);
 			end
 
 			else if(PLL_POST_DIV1==0)begin
-				$display("Error at time %t: \n \t PLL instance %m, PLL_POST_DIV1 is equal to zero.\n \t Must be greater than 0", $realtime);
-				$stop;
+				$fatal(1,"Error at time %t: \n \t PLL instance %m, PLL_POST_DIV1 is equal to zero.\n \t Must be greater than 0", $realtime);
 			end
 
 
 			else if(PLL_POST_DIV1>PLL_POST_DIV0) begin
-				$display("Error at time %t: PLL_POST_DIV1 > PLL_POST_DIV0\n", $realtime);
-				$stop;
+				$fatal(1,"Error at time %t: PLL_POST_DIV1 > PLL_POST_DIV0\n", $realtime);
 			end
 		end
 	end

--- a/models_internal/verilog/tb/I_FAB_tb.v
+++ b/models_internal/verilog/tb/I_FAB_tb.v
@@ -1,0 +1,43 @@
+
+module I_FAB_tb;
+
+  // Parameters
+
+  //Ports
+  reg  I;
+  wire  O;
+  int error;
+
+  I_FAB  I_FAB_inst (
+    .I(I),
+    .O(O)
+  );
+
+  initial 
+  begin
+    I = 0;
+    error = 0;
+    #3;
+    I = 1;
+    for(int i=0;i<=63;i++)
+	begin
+        #3;
+		I = $urandom;
+        #1;
+		if(O!==I)
+            error++;
+	end
+
+    if(error===0)
+        $display("I_FAB TEST PASSED");
+    else
+        $error("I_FAB TEST FAILED");
+            
+  end
+  initial 
+  begin
+      $dumpfile("waves.vcd");
+      $dumpvars;
+  end
+
+endmodule

--- a/models_internal/verilog/tb/O_FAB_tb.v
+++ b/models_internal/verilog/tb/O_FAB_tb.v
@@ -1,0 +1,43 @@
+
+module O_FAB_tb;
+
+  // Parameters
+
+  //Ports
+  reg  I;
+  wire  O;
+  int error;
+
+  O_FAB  O_FAB_inst (
+    .I(I),
+    .O(O)
+  );
+
+  initial 
+  begin
+    I = 0;
+    error = 0;
+    #3;
+    I = 1;
+    for(int i=0;i<=63;i++)
+	begin
+        #3;
+		I = $urandom;
+        #1;
+		if(O!==I)
+            error++;
+	end
+
+    if(error===0)
+        $display("O_FAB TEST PASSED");
+    else
+        $error("O_FAB TEST FAILED");
+            
+  end
+  initial 
+  begin
+      $dumpfile("waves.vcd");
+      $dumpvars;
+  end
+
+endmodule

--- a/models_internal/verilog_blackbox/cell_sim_blackbox.v
+++ b/models_internal/verilog_blackbox/cell_sim_blackbox.v
@@ -351,6 +351,20 @@ module I_DELAY #(
 endmodule
 `endcelldefine
 //
+// I_FAB black box model
+// Marker Buffer for periphery to fabric transition
+//
+// Copyright (c) 2024 Rapid Silicon, Inc.  All rights reserved.
+//
+`celldefine
+(* blackbox *)
+module I_FAB (
+  input logic I,
+  output logic O
+);
+endmodule
+`endcelldefine
+//
 // I_SERDES black box model
 // Input Serial Deserializer
 //
@@ -605,6 +619,20 @@ module O_DELAY #(
   output logic [5:0] DLY_TAP_VALUE,
   (* clkbuf_sink *)
   input logic CLK_IN,
+  output logic O
+);
+endmodule
+`endcelldefine
+//
+// O_FAB black box model
+// Marker Buffer for fabric to periphery transition
+//
+// Copyright (c) 2024 Rapid Silicon, Inc.  All rights reserved.
+//
+`celldefine
+(* blackbox *)
+module O_FAB (
+  input logic I,
   output logic O
 );
 endmodule
@@ -946,7 +974,9 @@ module TDP_RAM18KX2 #(
   input logic WEN_B2,
   input logic REN_A2,
   input logic REN_B2,
+  (* clkbuf_sink *)
   input logic CLK_A2,
+  (* clkbuf_sink *)
   input logic CLK_B2,
   input logic [1:0] BE_A2,
   input logic [1:0] BE_B2,

--- a/specs/I_DELAY.yaml
+++ b/specs/I_DELAY.yaml
@@ -89,3 +89,8 @@ parameters:
       default: 0
       range: 0 .. 63
 
+control_signal_map:
+    DLY_LOAD: f2g_rx_dly_ld
+    DLY_ADJ: f2g_rx_dly_adj
+    DLY_INCDEC: f2g_rx_dly_inc
+    DLY_TAP_VALUE: g2f_rx_dly_tap

--- a/specs/I_FAB.yaml
+++ b/specs/I_FAB.yaml
@@ -43,44 +43,14 @@
 #          - <enum_name>
 #
 # primitive name should match the filename root.
-name: O_SERDES_CLK
-desc: Output Serializer Clock
-category: periphery
+name: I_FAB
+desc: Marker Buffer for periphery to fabric transition
+category: core_fabric
 
 ports:
-   CLK_EN:
-     dir: input
-     desc: Gates output OUTPUT_CLK
-   OUTPUT_CLK:
+   I:
+     dir:  input
+     desc: Input
+   O:
      dir: output
-     desc: Clock output (Connect to output port, buffer or O_DELAY)
-     type: reg
-     default: 1'b0
-   PLL_LOCK:
-     dir: input
-     desc: PLL lock input
-   PLL_CLK:
-     dir: input
-     desc: PLL clock input
-
-# set as Verilog parameter in netlist    
-parameters:
-    DATA_RATE:
-      desc: Single or double data rate (SDR/DDR)
-      default: SDR
-      values:
-         - SDR
-         - DDR
-    CLOCK_PHASE:
-      desc: Clock phase (0,90,180,270)
-      type: integer
-      default: 0
-      values:
-        - 0
-        - 90
-        - 180
-        - 270
-
-control_signal_map:
-   CLK_EN: f2g_tx_clk_en
-   OUTPUT_CLK: g2i_tx_clk
+     desc: Output

--- a/specs/I_SERDES.yaml
+++ b/specs/I_SERDES.yaml
@@ -106,3 +106,14 @@ parameters:
         - NONE
         - DPA
         - CDR
+
+control_signal_map:
+   RST: f2g_rx_reset_n
+   BITSLIP_ADJ: f2g_rx_bitslip_adj
+   EN: f2g_in_en
+   CLK_IN: f2g_rx_core_clk
+   CLK_OUT: g2f_core_clk
+   Q[WIDTH-1:0]: g2f_rx_in
+   DATA_VALID: g2f_rx_dvalid
+   DPA_LOCK: g2f_rx_dpa_lock
+   DPA_ERROR: g2f_rx_dpa_error

--- a/specs/O_DELAY.yaml
+++ b/specs/O_DELAY.yaml
@@ -88,3 +88,8 @@ parameters:
       default: 0
       range: 0 .. 63
 
+control_signal_map:
+    DLY_LOAD: f2g_tx_dly_ld
+    DLY_ADJ: f2g_tx_dly_adj
+    DLY_INCDEC: f2g_tx_dly_inc
+    DLY_TAP_VALUE: g2f_tx_dly_tap

--- a/specs/O_FAB.yaml
+++ b/specs/O_FAB.yaml
@@ -43,44 +43,14 @@
 #          - <enum_name>
 #
 # primitive name should match the filename root.
-name: O_SERDES_CLK
-desc: Output Serializer Clock
-category: periphery
+name: O_FAB
+desc: Marker Buffer for fabric to periphery transition
+category: core_fabric
 
 ports:
-   CLK_EN:
-     dir: input
-     desc: Gates output OUTPUT_CLK
-   OUTPUT_CLK:
+   I:
+     dir:  input
+     desc: Input
+   O:
      dir: output
-     desc: Clock output (Connect to output port, buffer or O_DELAY)
-     type: reg
-     default: 1'b0
-   PLL_LOCK:
-     dir: input
-     desc: PLL lock input
-   PLL_CLK:
-     dir: input
-     desc: PLL clock input
-
-# set as Verilog parameter in netlist    
-parameters:
-    DATA_RATE:
-      desc: Single or double data rate (SDR/DDR)
-      default: SDR
-      values:
-         - SDR
-         - DDR
-    CLOCK_PHASE:
-      desc: Clock phase (0,90,180,270)
-      type: integer
-      default: 0
-      values:
-        - 0
-        - 90
-        - 180
-        - 270
-
-control_signal_map:
-   CLK_EN: f2g_tx_clk_en
-   OUTPUT_CLK: g2i_tx_clk
+     desc: Output

--- a/specs/O_SERDES.yaml
+++ b/specs/O_SERDES.yaml
@@ -96,3 +96,11 @@ parameters:
       type: integer
       default: 4
       range: 3 .. 10
+
+control_signal_map:
+   RST: f2g_tx_reset_n
+   DATA_VALID: f2g_tx_dvalid
+   CLK_IN: f2g_tx_core_clk
+   OE_IN: f2g_tx_oe
+   OE_OUT: g2i_tx_oe
+   Q: g2i_tx_out

--- a/specs/TDP_RAM18KX2.yaml
+++ b/specs/TDP_RAM18KX2.yaml
@@ -127,9 +127,11 @@ ports:
    CLK_A2:
      dir: input
      desc: Clock port A, RAM 2
+     bb_attributes: clkbuf_sink
    CLK_B2:
      dir: input
      desc: Clock port B, RAM 2
+     bb_attributes: clkbuf_sink
    BE_A2[1:0]:
      dir: input
      desc: Byte-write enable port A, RAM 2


### PR DESCRIPTION
This PR includes:
- internal port control signal in yaml
- added clk_buf_sink to tdp (EDA-3016) fixes
- changed $stop in all models to $fatal
- new primitives I_FAB and O_FAB