### PR TITLE
Updated PROG_FULL_Threshold deafualt value in FIFO36K & FIFO18KX2 yamal files

### DIFF
--- a/models_internal/verilog/FIFO18KX2.v
+++ b/models_internal/verilog/FIFO18KX2.v
@@ -12,12 +12,12 @@ module FIFO18KX2 #(
   parameter DATA_READ_WIDTH1 = 18, // FIFO data read width, FIFO 1 (9, 18)
   parameter FIFO_TYPE1 = "SYNCHRONOUS", // Synchronous or Asynchronous data transfer, FIFO 1 (SYNCHRONOUS/ASYNCHRONOUS)
   parameter [10:0] PROG_EMPTY_THRESH1 = 11'h004, // 11-bit Programmable empty depth, FIFO 1
-  parameter [10:0] PROG_FULL_THRESH1 = 11'h7fa, // 11-bit Programmable full depth, FIFO 1
+  parameter [10:0] PROG_FULL_THRESH1 = 11'hfa, // 11-bit Programmable full depth, FIFO 1
   parameter DATA_WRITE_WIDTH2 = 18, // FIFO data write width, FIFO 2 (9, 18)
   parameter DATA_READ_WIDTH2 = 18, // FIFO data read width, FIFO 2 (9, 18)
   parameter FIFO_TYPE2 = "SYNCHRONOUS", // Synchronous or Asynchronous data transfer, FIFO 2 (SYNCHRONOUS/ASYNCHRONOUS)
   parameter [10:0] PROG_EMPTY_THRESH2 = 11'h004, // 11-bit Programmable empty depth, FIFO 2
-  parameter [10:0] PROG_FULL_THRESH2 = 11'h7fa // 11-bit Programmable full depth, FIFO 2
+  parameter [10:0] PROG_FULL_THRESH2 = 11'hfa // 11-bit Programmable full depth, FIFO 2
 ) (
   input RESET1, // Active high asynchronous FIFO reset, FIFO 1
   input WR_CLK1, // Write clock, FIFO 1

--- a/models_internal/verilog/FIFO36K.v
+++ b/models_internal/verilog/FIFO36K.v
@@ -12,7 +12,7 @@ module FIFO36K #(
   parameter DATA_READ_WIDTH = 36, // FIFO data read width (9, 18, 36)
   parameter FIFO_TYPE = "SYNCHRONOUS", // Synchronous or Asynchronous data transfer (SYNCHRONOUS/ASYNCHRONOUS)
   parameter [11:0] PROG_EMPTY_THRESH = 12'h004, // 12-bit Programmable empty depth
-  parameter [11:0] PROG_FULL_THRESH = 12'hffa // 12-bit Programmable full depth
+  parameter [11:0] PROG_FULL_THRESH = 12'hfa // 12-bit Programmable full depth
 ) (
   input RESET, // Active high synchronous FIFO reset
   input WR_CLK, // Write clock

--- a/models_internal/verilog_blackbox/cell_sim_blackbox.v
+++ b/models_internal/verilog_blackbox/cell_sim_blackbox.v
@@ -99,6 +99,23 @@ module DFFRE (
 endmodule
 `endcelldefine
 //
+// DLY_SEL_DCODER black box model
+// Address Decoder
+//
+// Copyright (c) 2024 Rapid Silicon, Inc.  All rights reserved.
+//
+`celldefine
+(* blackbox *)
+module DLY_SEL_DCODER (
+  input logic DLY_LOAD,
+  input logic DLY_ADJ,
+  input logic DLY_INCDEC,
+  input logic [4:0] DLY_ADDR,
+  output reg [2:0] DLY_CNTRL[31:0]
+);
+endmodule
+`endcelldefine
+//
 // DLY_SEL_DECODER black box model
 // Address Decoder
 //
@@ -275,12 +292,12 @@ module FIFO18KX2 #(
   parameter DATA_READ_WIDTH1 = 18, // FIFO data read width, FIFO 1 (9, 18)
   parameter FIFO_TYPE1 = "SYNCHRONOUS", // Synchronous or Asynchronous data transfer, FIFO 1 (SYNCHRONOUS/ASYNCHRONOUS)
   parameter [10:0] PROG_EMPTY_THRESH1 = 11'h004, // 11-bit Programmable empty depth, FIFO 1
-  parameter [10:0] PROG_FULL_THRESH1 = 11'h7fa, // 11-bit Programmable full depth, FIFO 1
+  parameter [10:0] PROG_FULL_THRESH1 = 11'hfa, // 11-bit Programmable full depth, FIFO 1
   parameter DATA_WRITE_WIDTH2 = 18, // FIFO data write width, FIFO 2 (9, 18)
   parameter DATA_READ_WIDTH2 = 18, // FIFO data read width, FIFO 2 (9, 18)
   parameter FIFO_TYPE2 = "SYNCHRONOUS", // Synchronous or Asynchronous data transfer, FIFO 2 (SYNCHRONOUS/ASYNCHRONOUS)
   parameter [10:0] PROG_EMPTY_THRESH2 = 11'h004, // 11-bit Programmable empty depth, FIFO 2
-  parameter [10:0] PROG_FULL_THRESH2 = 11'h7fa // 11-bit Programmable full depth, FIFO 2
+  parameter [10:0] PROG_FULL_THRESH2 = 11'hfa // 11-bit Programmable full depth, FIFO 2
   ) (
   input logic RESET1,
   (* clkbuf_sink *)
@@ -332,7 +349,7 @@ module FIFO36K #(
   parameter DATA_READ_WIDTH = 36, // FIFO data read width (9, 18, 36)
   parameter FIFO_TYPE = "SYNCHRONOUS", // Synchronous or Asynchronous data transfer (SYNCHRONOUS/ASYNCHRONOUS)
   parameter [11:0] PROG_EMPTY_THRESH = 12'h004, // 12-bit Programmable empty depth
-  parameter [11:0] PROG_FULL_THRESH = 12'hffa // 12-bit Programmable full depth
+  parameter [11:0] PROG_FULL_THRESH = 12'hfa // 12-bit Programmable full depth
   ) (
   input logic RESET,
   (* clkbuf_sink *)

--- a/specs/FIFO18KX2.yaml
+++ b/specs/FIFO18KX2.yaml
@@ -202,7 +202,7 @@ parameters:
       vector: 11
     PROG_FULL_THRESH1:
       desc: 11-bit Programmable full depth, FIFO 1
-      default: 11'h7fa
+      default: 11'hfa
       vector: 11
     DATA_WRITE_WIDTH2:
       desc: FIFO data write width, FIFO 2 (9, 18)
@@ -230,6 +230,6 @@ parameters:
       vector: 11
     PROG_FULL_THRESH2:
       desc: 11-bit Programmable full depth, FIFO 2
-      default: 11'h7fa
+      default: 11'hfa
       vector: 11
 

--- a/specs/FIFO36K.yaml
+++ b/specs/FIFO36K.yaml
@@ -141,5 +141,5 @@ parameters:
       vector: 12
     PROG_FULL_THRESH:
       desc: 12-bit Programmable full depth
-      default: 12'hffa
+      default: 12'hfa
       vector: 12


### PR DESCRIPTION
Default value of Prog_empty_threshold and Prog_full_threshold values should be less than decimal 1022.   